### PR TITLE
캐릭터 밀리는 현상 임시 수정

### DIFF
--- a/Assets/0_Script/Player/PlayerManager.cs
+++ b/Assets/0_Script/Player/PlayerManager.cs
@@ -31,6 +31,7 @@ public class PlayerManager : MonoBehaviour
     private List<GameObject> mCurrentCollidingItems;
     private List<GameObject> mCurrentPickUpObjects;
     private bool hasConsumedSpaceKey;
+    private bool mIsKnockingBack;
 
     void Start()
     {
@@ -46,6 +47,7 @@ public class PlayerManager : MonoBehaviour
         mCurrentCollidingItems = new List<GameObject>();
         mCurrentPickUpObjects = new List<GameObject>();
         hasConsumedSpaceKey = false;
+        mIsKnockingBack = false;
     }
 
     void FixedUpdate()
@@ -91,6 +93,12 @@ public class PlayerManager : MonoBehaviour
         {
             SetCurrentState(PlayerState.walk);
         }
+        
+        if (mIsKnockingBack == false)
+        {
+            myRigidbody.velocity = Vector2.zero;
+        }
+
         if(currentState == PlayerState.walk || currentState == PlayerState.run
             || currentState == PlayerState.idle)
         {
@@ -199,6 +207,7 @@ public class PlayerManager : MonoBehaviour
         playerHealthSignal.Raise();
         if(currentHealth.RuntimeValue > 0)
         {
+            mIsKnockingBack = true;
             StartCoroutine(KnockCo(knockTime));
         }
         else
@@ -216,6 +225,7 @@ public class PlayerManager : MonoBehaviour
             currentState = PlayerState.walk;
                 //넉백을 받으면 공주가 자꾸 가만히 멈춰서서 idle 에서 walk로 고쳐봤음
             myRigidbody.velocity = Vector2.zero;
+            mIsKnockingBack = false;
         }
     }
   


### PR DESCRIPTION
현상: 충돌 처리 시 Player의 Rigidbody2D component에 horizontal velocity가 생김
원인: 충돌 처리 시 player에게 knockback 느낌으로 velocity를 주는 것 같은데, player와 땅 사이에 friction이 없어서 관성에 의해 계속 밀리는 것으로 **추정** 중임
해결: 근본적인 해결은 필자의 유니티 이해 부족으로 하지 못하였음. 대신 update 루프에서 velocity가 바뀌어야 하는 상황이 아닐 때에는 velocity를 zero로 셋팅하도록 임시 코드를 추가함